### PR TITLE
Add Comment Mutation

### DIFF
--- a/client/src/components/CommentForm/index.js
+++ b/client/src/components/CommentForm/index.js
@@ -1,8 +1,15 @@
 import * as React from 'react';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
+import { useState } from 'react';
+import CommentFormButton from '../CommentFormButton';
 
-export default function CommentForm() {
+export default function CommentForm(props) {
+
+  const handleInputChange = (event) => {
+    props.setUserInput(event.target.value);
+  }
+
   return (
     <Box
       component="form"
@@ -13,13 +20,17 @@ export default function CommentForm() {
       autoComplete="off"
     >
       <div>
-      <TextField
+        <TextField
           id="outlined-textarea"
           label="Comment Here"
           placeholder="Comment"
+          name="body"
+          value={props.userInput}
+          onChange={handleInputChange}
           multiline
         />
       </div>
-      </Box>
+      <CommentFormButton onClick={ props.onClick }/>
+    </Box>
   );
 }

--- a/client/src/components/CommentFormButton/index.js
+++ b/client/src/components/CommentFormButton/index.js
@@ -2,10 +2,10 @@ import * as React from 'react';
 import Button from '@mui/material/Button';
 import { Link } from 'react-router-dom';
 
-export default function CommentFormButton() {
+export default function CommentFormButton({ onClick }) {
     return (
 
-        <Button variant="contained">
+        <Button variant="contained" onClick={onClick}>
             Submit Comment
         </Button>
     );

--- a/client/src/components/DisplaySingleRequest/index.js
+++ b/client/src/components/DisplaySingleRequest/index.js
@@ -12,6 +12,7 @@ import DrawIcon from '@mui/icons-material/Draw';
 import { ADD_COMMENT } from '../../utils/mutations';
 import { useMutation } from '@apollo/client';
 import { useState } from 'react';
+import { QUERY_SINGLE_REQUEST } from '../../utils/queries';
 
 export default function SingleRequest({ request }) {
 
@@ -29,8 +30,15 @@ export default function SingleRequest({ request }) {
         variables: {
           body: userInput,
           requestId: request._id
-        }
-      })
+        },
+        refetchQueries: [
+          {query: QUERY_SINGLE_REQUEST,
+            variables: {
+              id: request._id
+            }
+          }
+        ]
+      });
     } 
     catch (error) {
       console.error('Mutation error: ', error.message)

--- a/client/src/components/DisplaySingleRequest/index.js
+++ b/client/src/components/DisplaySingleRequest/index.js
@@ -9,8 +9,44 @@ import CommentForm from '../CommentForm';
 import CommentFormButton from '../CommentFormButton';
 import DisplayComment from '../DisplayComment';
 import DrawIcon from '@mui/icons-material/Draw';
+import { ADD_COMMENT } from '../../utils/mutations';
+import { useMutation } from '@apollo/client';
+import { useState } from 'react';
 
 export default function SingleRequest({ request }) {
+
+  const [userInput, setUserInput] = useState('')
+
+  const [addCommentMutation, { data, loading, error }] = useMutation(ADD_COMMENT);
+
+  if (loading) return 'Submitting...';
+  if (error) return `Submission error! ${error.message}`;
+
+  const handleMutation = async (userInput) => {
+    try {
+      console.log('Mutation runs')
+      await addCommentMutation({
+        variables: {
+          body: userInput,
+          requestId: request._id
+        }
+      })
+    } 
+    catch (error) {
+      console.error('Mutation error: ', error.message)
+    }
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    try {
+      handleMutation(userInput);
+    } 
+    catch (error) {
+      console.error('Mutation error: ', error.message)
+    }
+  };
+
   return (
     <div>
       <Card className="request-card" key={request._id}>
@@ -27,8 +63,8 @@ export default function SingleRequest({ request }) {
         </Typography>
       </Card>
       <ClaimRequestButton />
-      <CommentForm />
-      <CommentFormButton />
+      <CommentForm onClick={handleSubmit} userInput={userInput} setUserInput={setUserInput}/>
+      {/* <CommentFormButton onClick={handleSubmit}/> */}
       <DisplayComment comments={request.comments}/>
     </div>
   );

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -73,16 +73,15 @@ mutation Mutation($_id: ID!) {
 
 
 export const ADD_COMMENT = gql`
-mutation AddComment($requestId: ID, $body: String!) {
-  addComment(requestId: $requestId, body: $body) {
-    comment {
+mutation AddComment($body: String!, $requestId: ID) {
+  addComment(body: $body, requestId: $requestId) {
+    _id
+    authorId {
       _id
-      body
-      authorId {
-        _id
-        username
-      }
+      username
     }
+    body
+    createdAt
   }
 }
 `


### PR DESCRIPTION
Comment mutation succeeds in run.
Comment adds and displays on single request page (it re-renders the page by refetching the display request query).
Moved button comment to appear on form instead.

Cleanup needed for console logs.